### PR TITLE
Update KiNET plugin README for Port out

### DIFF
--- a/plugins/kinet/README.md
+++ b/plugins/kinet/README.md
@@ -19,11 +19,12 @@ The mode of KiNET to send to the power supply. DMX Out is sometimes known as V1
 and Port Out as V2.
 
 In general, it is highly recommended to use the Port Out mode if your power
-supply supports it. OLA defaults to DMX Out mode for backwards compatibility
-reasons. Note that some newer devices only support the Port Out protocol. On
-some devices it is also necessary to use the Port Out protocol in order to
-address all of the connected fixtures if the number of channels required
-exceeds one universe.
+supply supports it. Only very old devices do not support Port Out mode, so it
+is recommended to try Port Out mode first. OLA defaults to DMX Out mode for
+backwards compatibility reasons. Note that some newer devices only support the
+Port Out protocol. On some devices it is also necessary to use the Port Out
+protocol in order to address all of the connected fixtures if the number of
+channels required exceeds one universe.
 
 Note that for the DMX Out mode the universe option on the power supply will be
 ignored, as this plugin only supports unicast DMX Out packets destined for the
@@ -33,4 +34,5 @@ patched by assigning this output port to the intended universe in OLA.
 `<ip>-ports = <int>`
 The number of physical ports available on the power supply in Port Out mode.
 Each physical port will create an OLA port that may be assigned to any
-universe. This setting is ignored in DMX Out mode.
+universe. This setting is ignored in DMX Out mode. The default and maximum
+number of ports per power supply supported by OLA is 16.

--- a/plugins/kinet/README.md
+++ b/plugins/kinet/README.md
@@ -8,6 +8,8 @@ Port Out (V2) modes of the KiNET protocol.
 
 ## Config file: `ola-kinet.conf`
 
+### Per Power Supply Settings
+
 `power_supply = <ip>`
 The IP of the power supply to send to. You can communicate with more than
 one power supply by adding multiple `power_supply =` lines.

--- a/plugins/kinet/README.md
+++ b/plugins/kinet/README.md
@@ -36,4 +36,4 @@ in OLA.
 The number of physical ports available on the power supply in Port Out mode.
 Each physical port will create an OLA port that may be assigned to any
 universe. This setting is ignored in DMX Out mode. The default and maximum
-number of ports per power supply supported by OLA is 16.
+number of ports per power supply is 16.

--- a/plugins/kinet/README.md
+++ b/plugins/kinet/README.md
@@ -2,8 +2,8 @@ KiNET Plugin
 ============
 
 This plugin creates a single device with multiple output ports. Each port
-represents a power supply. This plugin supports both the V1 DMX out and the
-V2 Port out modes of the KiNET protocol.
+represents a power supply. This plugin supports both the DMX Out (V1) and the
+Port Out (V2) modes of the KiNET protocol.
 
 
 ## Config file: `ola-kinet.conf`
@@ -12,21 +12,22 @@ V2 Port out modes of the KiNET protocol.
 The IP of the power supply to send to. You can communicate with more than
 one power supply by adding multiple `power_supply =` lines.
 
-`<ip>-mode = [v1dmxout|v2portout]`
-The mode of KiNET to send to the power supply.
+`<ip>-mode = [dmxout|portout]`
+The mode of KiNET to send to the power supply. DMX Out is sometimes known as V1
+and Port Out as V2.
 
-In general, it is highly recommended to use the V2 Port out mode if your power
-supply supports it. Note that some newer devices only support the V2 Port out
-protocol. On some devices it is also necessary to use the V2 Port out protocol
-in order to address all of the connected fixtures if the number of channels
+In general, it is highly recommended to use the Port Out mode if your power
+supply supports it. Note that some newer devices only support the Port Out
+protocol. On some devices it is also necessary to use the Port Out protocol in
+order to address all of the connected fixtures if the number of channels
 required exceeds one universe.
 
-Note that for DMX out mode, the universe option on the power supply will be
-ignored, as this plugin supports only unicast DMX out packets. Instead, the
-universe may be patched by assigning this output port to the intended universe
-in OLA.
+Note that for the DMX Out mode the universe option on the power supply will be
+ignored, as this plugin supports only unicast DMX Out packets destined for the
+broadcast universe on each device. Instead, the universe for each device may be
+patched by assigning this output port to the intended universe in OLA.
 
-`<ip>-ports = [int]`
-The number of physical ports available on the power supply in V2 Port out mode.
+`<ip>-ports = <int>`
+The number of physical ports available on the power supply in Port Out mode.
 Each physical port will create an OLA port that may be assigned to any
-universe. This setting is ignored in V1 DMX out mode.
+universe. This setting is ignored in DMX Out mode.

--- a/plugins/kinet/README.md
+++ b/plugins/kinet/README.md
@@ -2,12 +2,31 @@ KiNET Plugin
 ============
 
 This plugin creates a single device with multiple output ports. Each port
-represents a power supply. This plugin uses the V1 DMX-Out version of the
-KiNET protocol.
+represents a power supply. This plugin supports both the V1 DMX out and the
+V2 Port out modes of the KiNET protocol.
 
 
 ## Config file: `ola-kinet.conf`
 
-`power_supply = <ip>`  
+`power_supply = <ip>`
 The IP of the power supply to send to. You can communicate with more than
-one power supply by adding multiple `power_supply =` lines
+one power supply by adding multiple `power_supply =` lines.
+
+`<ip>-mode = [v1dmxout|v2portout]`
+The mode of KiNET to send to the power supply.
+
+In general, it is highly recommended to use the V2 Port out mode if your power
+supply supports it. Note that some newer devices only support the V2 Port out
+protocol. On some devices it is also necessary to use the V2 Port out protocol
+in order to address all of the connected fixtures if the number of channels
+required exceeds one universe.
+
+Note that for DMX out mode, the universe option on the power supply will be
+ignored, as this plugin supports only unicast DMX out packets. Instead, the
+universe may be patched by assigning this output port to the intended universe
+in OLA.
+
+`<ip>-ports = [int]`
+The number of physical ports available on the power supply in V2 Port out mode.
+Each physical port will create an OLA port that may be assigned to any
+universe. This setting is ignored in V1 DMX out mode.

--- a/plugins/kinet/README.md
+++ b/plugins/kinet/README.md
@@ -8,25 +8,26 @@ Port Out (V2) modes of the KiNET protocol.
 
 ## Config file: `ola-kinet.conf`
 
-### Per Power Supply Settings
-
 `power_supply = <ip>`
 The IP of the power supply to send to. You can communicate with more than
 one power supply by adding multiple `power_supply =` lines.
+
+### Per Power Supply Settings
 
 `<ip>-mode = [dmxout|portout]`
 The mode of KiNET to send to the power supply. DMX Out is sometimes known as V1
 and Port Out as V2.
 
 In general, it is highly recommended to use the Port Out mode if your power
-supply supports it. Note that some newer devices only support the Port Out
-protocol. On some devices it is also necessary to use the Port Out protocol in
-order to address all of the connected fixtures if the number of channels
-required exceeds one universe.
+supply supports it. OLA defaults to DMX Out mode for backwards compatibility
+reasons. Note that some newer devices only support the Port Out protocol. On
+some devices it is also necessary to use the Port Out protocol in order to
+address all of the connected fixtures if the number of channels required
+exceeds one universe.
 
 Note that for the DMX Out mode the universe option on the power supply will be
-ignored, as this plugin supports only unicast DMX Out packets destined for the
-broadcast universe on each device. Instead, the universe for each device may be
+ignored, as this plugin only supports unicast DMX Out packets destined for the
+wildcard universe on each device. Instead, the universe for each device may be
 patched by assigning this output port to the intended universe in OLA.
 
 `<ip>-ports = <int>`

--- a/plugins/kinet/README.md
+++ b/plugins/kinet/README.md
@@ -2,8 +2,8 @@ KiNET Plugin
 ============
 
 This plugin creates a single device with multiple output ports. Each port
-represents a power supply. This plugin supports both the DMX Out (V1) and the
-Port Out (V2) modes of the KiNET protocol.
+represents a power supply. This plugin supports both the DMX Out (V1) and
+the Port Out (V2) modes of the KiNET protocol.
 
 
 ## Config file: `ola-kinet.conf`
@@ -15,21 +15,22 @@ one power supply by adding multiple `power_supply =` lines.
 ### Per Power Supply Settings
 
 `<ip>-mode = [dmxout|portout]`
-The mode of KiNET to send to the power supply. DMX Out is sometimes known as V1
-and Port Out as V2.
+The mode of KiNET to send to the power supply. DMX Out is sometimes known as
+V1 and Port Out as V2.
 
 In general, it is highly recommended to use the Port Out mode if your power
-supply supports it. Only very old devices do not support Port Out mode, so it
-is recommended to try Port Out mode first. OLA defaults to DMX Out mode for
-backwards compatibility reasons. Note that some newer devices only support the
-Port Out protocol. On some devices it is also necessary to use the Port Out
-protocol in order to address all of the connected fixtures if the number of
-channels required exceeds one universe.
+supply supports it. Only very old devices do not support Port Out mode, so
+it is recommended to try Port Out mode first. OLA defaults to DMX Out mode
+for backwards compatibility reasons. Note that some newer devices only
+support the Port Out protocol. On some devices it is also necessary to use
+the Port Out protocol in order to address all of the connected fixtures if
+the number of channels required exceeds one universe.
 
-Note that for the DMX Out mode the universe option on the power supply will be
-ignored, as this plugin only supports unicast DMX Out packets destined for the
-wildcard universe on each device. Instead, the universe for each device may be
-patched by assigning this output port to the intended universe in OLA.
+Note that for the DMX Out mode the universe option on the power supply will
+be ignored, as this plugin only supports unicast DMX Out packets destined
+for the wildcard universe on each device. Instead, the universe for each
+device may be patched by assigning this output port to the intended universe
+in OLA.
 
 `<ip>-ports = <int>`
 The number of physical ports available on the power supply in Port Out mode.


### PR DESCRIPTION
cc https://github.com/OpenLightingProject/ola/pull/1787

Relatedly, where is/how is the default `ola-kinet.conf` created that is placed by default at first launch of OLA?