### PR TITLE
KiNET Fix KiNetNode Static Private Constant Variables

### DIFF
--- a/plugins/kinet/KiNetNode.cpp
+++ b/plugins/kinet/KiNetNode.cpp
@@ -38,6 +38,13 @@ using ola::network::IPV4SocketAddress;
 using ola::network::UDPSocket;
 using std::auto_ptr;
 
+const uint16_t KiNetNode::KINET_PORT = 6038;
+const uint32_t KiNetNode::KINET_MAGIC_NUMBER = 0x0401dc4a;
+const uint16_t KiNetNode::KINET_VERSION_ONE = 0x0100;
+const uint16_t KiNetNode::KINET_DMX_MSG = 0x0101;
+const uint16_t KiNetNode::KINET_PORTOUT_MSG = 0x0801;
+const uint16_t KiNetNode::KINET_PORTOUT_MIN_BUFFER_SIZE = 24;
+
 /*
  * Create a new KiNet node.
  * @param ss a SelectServerInterface to use

--- a/plugins/kinet/KiNetNode.h
+++ b/plugins/kinet/KiNetNode.h
@@ -68,12 +68,12 @@ class KiNetNode {
     void PopulatePacketHeader(uint16_t msg_type);
     bool InitNetwork();
 
-    static const uint16_t KINET_PORT = 6038;
-    static const uint32_t KINET_MAGIC_NUMBER = 0x0401dc4a;
-    static const uint16_t KINET_VERSION_ONE = 0x0100;
-    static const uint16_t KINET_DMX_MSG = 0x0101;
-    static const uint16_t KINET_PORTOUT_MSG = 0x0801;
-    static const uint16_t KINET_PORTOUT_MIN_BUFFER_SIZE = 24;
+    static const uint16_t KINET_PORT;
+    static const uint32_t KINET_MAGIC_NUMBER;
+    static const uint16_t KINET_VERSION_ONE;
+    static const uint16_t KINET_DMX_MSG;
+    static const uint16_t KINET_PORTOUT_MSG;
+    static const uint16_t KINET_PORTOUT_MIN_BUFFER_SIZE;
 
     DISALLOW_COPY_AND_ASSIGN(KiNetNode);
 };


### PR DESCRIPTION
Fixes C++ linker error from constants both defined and declared in the header. Fixes Debian build.

Fixes issue found beginning with comment here: https://github.com/OpenLightingProject/ola/pull/1787#issuecomment-1472782940

Codespell lint failure is unrelated.